### PR TITLE
Update appgw.bicep

### DIFF
--- a/reference-implementations/AppGW-IAPIM-Func/bicep/gateway/appgw.bicep
+++ b/reference-implementations/AppGW-IAPIM-Func/bicep/gateway/appgw.bicep
@@ -170,7 +170,8 @@ resource appGatewayName_resource 'Microsoft.Network/applicationGateways@2019-09-
           pickHostNameFromBackendAddress: false
           requestTimeout: 20
           probe: {
-            id: '${resourceId('Microsoft.Network/applicationGateways', appGatewayName)}/probes/APIM'
+            #id: '${resourceId('Microsoft.Network/applicationGateways', appGatewayName)}/probes/APIM'
+            id: 'subscriptionResourceId('Microsoft.Network/applicationGateways', appGatewayName/probes/APIM')
           }
         }
       }


### PR DESCRIPTION
changed this  #id: '${resourceId('Microsoft.Network/applicationGateways', appGatewayName)}/probes/APIM' to below
            id: 'subscriptionResourceId('Microsoft.Network/applicationGateways', appGatewayName/probes/APIM')